### PR TITLE
Commitable cache

### DIFF
--- a/src/JsLocalization/CachingService.php
+++ b/src/JsLocalization/CachingService.php
@@ -24,6 +24,23 @@ class CachingService
      */
     const CACHE_TIMESTAMP_KEY = 'js-localization-last-modified';
 
+    private $old_cache_driver;
+    private $old_cache_file_location;
+
+    public function __construct()
+    {
+        $this->old_cache_driver = Config::get('cache.driver');
+        $this->old_cache_file_location = Config::get('cache.path');
+        Config::set('cache.driver', 'file');
+        Config::set('cache.path', app_path('database/js-localization'));
+    }
+
+    public function __destruct()
+    {
+        Config::set('cache.driver', $this->old_cache_driver);
+        Config::set('cache.path',$this->old_cache_file_location);
+    }
+
     /**
      * Returns the cached messages (already JSON encoded).
      * Creates the neccessary cache item if neccessary.
@@ -103,7 +120,7 @@ class CachingService
 
     /**
      * Returns the translated messages for the given keys.
-     * 
+     *
      * @param array $messageKeys
      * @param $locale
      * @return array The translated messages as array( <message id> => <translation>, ... )

--- a/src/JsLocalization/CachingService.php
+++ b/src/JsLocalization/CachingService.php
@@ -24,21 +24,46 @@ class CachingService
      */
     const CACHE_TIMESTAMP_KEY = 'js-localization-last-modified';
 
-    private $old_cache_driver;
-    private $old_cache_file_location;
+    /**
+     * A property to remember the cache driver used by the app.
+     * @var string
+     */
+    private $app_cache_driver = '';
 
+    /**
+     * A property to remember the cache path used by the app.
+     * @var string
+     */
+    private $app_cache_path = '';
+
+    /**
+     * If we're using commitable_cache option then set the cache
+     * to use file system and a custom path.
+     *
+     * @return void
+     */
     public function __construct()
     {
-        $this->old_cache_driver = Config::get('cache.driver');
-        $this->old_cache_file_location = Config::get('cache.path');
-        Config::set('cache.driver', 'file');
-        Config::set('cache.path', app_path('database/js-localization'));
+        if (Config::get('js-localization::config.commitable_cache')) {
+            $this->app_cache_driver = Config::get('cache.driver');
+            $this->app_cache_path = Config::get('cache.path');
+            Config::set('cache.driver', 'file');
+            Config::set('cache.path', app_path('database/js-localization'));
+        }
     }
 
+    /**
+     * If we're using commitable_cache option then change the cache
+     * settings back to what they were before implementing this class.
+     *
+     * @return void
+     */
     public function __destruct()
     {
-        Config::set('cache.driver', $this->old_cache_driver);
-        Config::set('cache.path',$this->old_cache_file_location);
+        if (Config::get('js-localization::config.commitable_cache')) {
+            Config::set('cache.driver', $this->app_cache_driver);
+            Config::set('cache.path',$this->app_cache_path);
+        }
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -12,6 +12,20 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Commitable cache
+    |--------------------------------------------------------------------------
+    |
+    | Set to true to store the messages cache in a file that can be committed
+    | to version control. This is so you don't need to remember to run
+    | `php artisan js-localization:refresh` in your production environment
+    | every time you push an update.
+    |
+    */
+
+    'commitable_cache' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Define the messages to export
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This is so a user can refresh the cache, then commit the new messages file in version control, instead of having to remember to run the refresh command on production.