### PR TITLE
optimizing routes

### DIFF
--- a/resources/views/head.blade.php
+++ b/resources/views/head.blade.php
@@ -2,3 +2,7 @@
     <script type="text/javascript" src="{{ url('/js-localization/localization.js') }}"></script>
     <script type="text/javascript" src="{{ url('/js-localization/messages') }}"></script>
 @stop
+
+@section('js-localization.head.all_in_one')
+    <script type="text/javascript" src="{{ url('/js-localization/all.js') }}"></script>
+@stop

--- a/src/Http/Controllers/JsLocalizationController.php
+++ b/src/Http/Controllers/JsLocalizationController.php
@@ -35,4 +35,13 @@ class JsLocalizationController extends Controller
         }
     }
 
+    public function deliverLocalizationJS()
+    {
+        $response = new StaticFileResponse( __DIR__."/../../public/js/localization.min.js" );
+        $response->setPublic();
+        $response->header('Content-Type', 'application/javascript');
+
+        return $response;
+    }
+
 }

--- a/src/Http/Controllers/JsLocalizationController.php
+++ b/src/Http/Controllers/JsLocalizationController.php
@@ -6,6 +6,7 @@ use DateTime;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Lang;
 use JsLocalization\Facades\CachingService;
+use JsLocalization\Http\Responses\StaticFileResponse;
 
 class JsLocalizationController extends Controller
 {

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -6,4 +6,6 @@ Route::group([ 'namespace' => '\JsLocalization\Http\Controllers' ], function()
 {
     Route::get('/js-localization/messages', 'JsLocalizationController@createJsMessages');
     Route::get('/js-localization/localization.js', 'JsLocalizationController@deliverLocalizationJS');
+
+    Route::get('/js-localization/all.js', 'JsLocalizationController@deliverLocalizationJSAndMessages');
 });

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -1,6 +1,5 @@
 <?php
 
-use JsLocalization\Http\Responses\StaticFileResponse;
 
 Route::group([ 'namespace' => '\JsLocalization\Http\Controllers' ], function()
 {

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -5,13 +5,5 @@ use JsLocalization\Http\Responses\StaticFileResponse;
 Route::group([ 'namespace' => '\JsLocalization\Http\Controllers' ], function()
 {
     Route::get('/js-localization/messages', 'JsLocalizationController@createJsMessages');
-
-    Route::get('/js-localization/localization.js', function()
-    {
-        $response = new StaticFileResponse( __DIR__."/../../public/js/localization.min.js" );
-        $response->setPublic();
-        $response->header('Content-Type', 'application/javascript');
-
-        return $response;
-    });
+    Route::get('/js-localization/localization.js', 'JsLocalizationController@deliverLocalizationJS');
 });


### PR DESCRIPTION
I moved the `localization.js` route function into the controller because Laravel can't handle closures when caching routes.

Furthermore I added a route that combines the translation messages and the Javascript functions to get them into one file. I think you should use as few HTTP-Requests as possible. This is a way to do so :)
