### PR TITLE
Disable backwards compatibility in the config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -48,5 +48,13 @@ return [
     |--------------------------------------------------------------------------
     */
     'disable_config_cache' => false,
-
+    
+        /*
+    |--------------------------------------------------------------------------
+    | Enables backward compatility, disable this to be able to handle locales like
+    | `nl_NL` and `es-mx` as the backward compatibility checker only allows locales that are
+    | two characters
+    |--------------------------------------------------------------------------
+    */
+    'enable_backward_compatibility' => false
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -56,5 +56,5 @@ return [
     | two characters
     |--------------------------------------------------------------------------
     */
-    'enable_backward_compatibility' => false
+    'ensure_backwards_compatibility' => false
 ];

--- a/src/Http/Controllers/JsLocalizationController.php
+++ b/src/Http/Controllers/JsLocalizationController.php
@@ -107,8 +107,11 @@ class JsLocalizationController extends Controller
     protected function getMessagesJson()
     {
         $messages = MessageCachingService::getMessagesJson();
-        $messages = $this->ensureBackwardsCompatibility($messages);
-
+        
+        if(Config::get('js-localization.ensure_backwards_compatibility')) {
+            $messages = $this->ensureBackwardsCompatibility($messages);
+        }
+        
         $contents  = 'Lang.addMessages(' . $messages . ');';
 
         return $contents;

--- a/src/Http/Controllers/JsLocalizationController.php
+++ b/src/Http/Controllers/JsLocalizationController.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Controller;
 use JsLocalization\Facades\ConfigCachingService;
 use JsLocalization\Facades\MessageCachingService;
 use JsLocalization\Http\Responses\StaticFileResponse;
+use Config;
 
 class JsLocalizationController extends Controller
 {


### PR DESCRIPTION
The backwards compatibility check only allows for languages, not for locales. They have to be 2 characters ('[a-z]{2}'), so locales like nl_NL and es-mx are causing issues.
This fix allows you to disable the backwards compatibility fix.

It solves #20 
