### PR TITLE
Update register command to work with 5.4

### DIFF
--- a/src/JsLocalizationServiceProvider.php
+++ b/src/JsLocalizationServiceProvider.php
@@ -64,12 +64,11 @@ class JsLocalizationServiceProvider extends ServiceProvider {
 	 */
 	private function registerRefreshCommand()
 	{
-		$this->app['js-localization.refresh'] = $this->app->share(function()
-		{
-			return new RefreshCommand;
-		});
-
-		$this->commands('js-localization.refresh');
+		if ($this->app->runningInConsole()) {
+	        	$this->commands([
+		            RefreshCommand::class
+	        	]);
+	    	}
 	}
 
 }


### PR DESCRIPTION
Share has been removed. So I've followed this approach:

https://laravel.com/docs/5.4/packages#commands

Fixes #31.