### PR TITLE
Fix for Laravel 5.4

### DIFF
--- a/src/JsLocalizationServiceProvider.php
+++ b/src/JsLocalizationServiceProvider.php
@@ -64,7 +64,7 @@ class JsLocalizationServiceProvider extends ServiceProvider {
 	 */
 	private function registerRefreshCommand()
 	{
-		$this->app['js-localization.refresh'] = $this->app->share(function()
+		$this->app->singleton('js-localization.refresh', function()
 		{
 			return new RefreshCommand;
 		});


### PR DESCRIPTION
Laravel 5.4 drops support for `$app->share()` favouring `$app->singleton()` instead.

Fixes #31.