### PR TITLE
Allow saving to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,9 @@ The messages configuration will be cached when the JsLocalizationController is u
 Usage
 -----
 
-The translation assets can either be generated at run-time, by requesting them from the route endpoints registered by the js-localization package, or they can be pre-generated as static JavaScript files, served straight from your web server or CDN, or to be included in your build process.
+The translation resources for JavaScript can either be served by your Laravel app at run-time or they can be pre-generated as static JavaScript files, allowing you to serve them straight from your web server or CDN or to be included in your build process.
 
 ### Run-time generation
-
-The normal way to use the package is to add the header tags that points to the endpoints registered by the package.
 
 You just need to add the necessary `<script>` tags to your layout. Here is an example blade view:
 
@@ -135,11 +133,11 @@ Remember it's best to not put the `@yield('js-localization.head')` in the `<head
 shipping the frontend part of this package. It's best practice to put it at the end of the `<body>`, but **before**
 other `<script>` tags. The example above simply includes it in the head, since it's the simplest form to use it. 
 
-### Static generated assets
+### Static generation
 
-For increased performance it is possible to generate statis JavaScript files with all of your generated strings. These files can either be served directly as static files, or included as a part of your frontend asset build process.
+For increased performance it is possible to generate static JavaScript files with all of your generated strings. These files can either be served directly as static files, or included as a part of your frontend asset build process.
 
-To specify the output dir for the assets, just add a `$storage_path` string to your configuration file.
+To specify the output directory for the assets, just set the `$storage_path` string in your `config/js-localization.php` file accordingly (see [Configuration](#configuration)).
 
 ```
     /*
@@ -158,7 +156,7 @@ The files can then be generated using the artisan command:
 
 `php artisan js-localization:export`
 
-This will generate two files in your target dir
+This will generate two files in your target directory:
  * `messags.js` contains your translation strings
  * `config.js` contains your exported config values
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The messages configuration will be cached when the JsLocalizationController is u
 Usage
 -----
 
+### Run-time generation
+
+The normal way to use the package is to add the header tags that points to the endpoints registered by the package.
+
 You just need to add the necessary `<script>` tags to your layout. Here is an example blade view:
 
 ```html
@@ -129,6 +133,32 @@ Remember it's best to not put the `@yield('js-localization.head')` in the `<head
 shipping the frontend part of this package. It's best practice to put it at the end of the `<body>`, but **before**
 other `<script>` tags. The example above simply includes it in the head, since it's the simplest form to use it. 
 
+### Static generated assets
+
+For increased performance it is possible to generate statis JavaScript files with all of your generated strings. These files can either be served directly as static files, or included as a part of your frontend asset build process.
+
+To specify the output dir for the assets, just add a `$storage_path` string to your configuration file.
+
+```
+    /*
+    |--------------------------------------------------------------------------
+    | Define the target to save the exported messages to
+    |--------------------------------------------------------------------------
+    |
+    | Directory for storing the static files generated when using file storage.
+    |
+    */
+
+    'storage_path' => public_path('vendor/js-localization/'),
+```
+
+The files can then be generated using the artisan command:
+
+`php artisan js-localization:export`
+
+This will generate two files in your target dir
+ * `messags.js` contains your translation strings
+ * `config.js` contains your exported config values
 
 Features
 --------

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The messages configuration will be cached when the JsLocalizationController is u
 Usage
 -----
 
+The translation assets can either be generated at run-time, by requesting them from the route endpoints registered by the js-localization package, or they can be pre-generated as static JavaScript files, served straight from your web server or CDN, or to be included in your build process.
+
 ### Run-time generation
 
 The normal way to use the package is to add the header tags that points to the endpoints registered by the package.
@@ -159,6 +161,8 @@ The files can then be generated using the artisan command:
 This will generate two files in your target dir
  * `messags.js` contains your translation strings
  * `config.js` contains your exported config values
+
+Remember that the files needs to be regenerated using `php artisan js-localization:export` every time any translation strings are edited, added or removed.
 
 Features
 --------

--- a/config/config.php
+++ b/config/config.php
@@ -15,22 +15,6 @@ return [
     | Define the target to save the exported messages to
     |--------------------------------------------------------------------------
     |
-    | A string defining where the messages should be saved.
-    |
-    | Possible options:
-    |  - cache: Uses the app's standard cache (default).
-    |  - file: Store the translations in a static file for direct inclusion in
-    |    markup, or for compilation with other assets.
-    |
-    */
-
-    'storage' => 'cache',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Define the target to save the exported messages to
-    |--------------------------------------------------------------------------
-    |
     | Directory for storing the static files generated when using file storage.
     |
     */

--- a/config/config.php
+++ b/config/config.php
@@ -12,6 +12,33 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Define the target to save the exported messages to
+    |--------------------------------------------------------------------------
+    |
+    | A string defining where the messages should be saved.
+    |
+    | Possible options:
+    |  - cache: Uses the app's standard cache (default).
+    |  - file: Store the translations in a static file for direct inclusion in
+    |    markup, or for compilation with other assets.
+    |
+    */
+
+    'storage' => 'cache',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Define the target to save the exported messages to
+    |--------------------------------------------------------------------------
+    |
+    | Directory for storing the static files generated when using file storage.
+    |
+    */
+
+    'storage_path' => public_path('vendor/js-localization/'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Define the messages to export
     |--------------------------------------------------------------------------
     |

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -1,0 +1,110 @@
+<?php
+namespace JsLocalization\Console;
+
+use Config;
+use Illuminate\Console\Command;
+use File;
+use JsLocalization\Exceptions\ConfigException;
+use JsLocalization\Facades\ConfigCachingService;
+use JsLocalization\Facades\MessageCachingService;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ExportCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'js-localization:export';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = "Refresh message cache and export to static files";
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     * @throws ConfigException
+     */
+    public function fire()
+    {
+        $this->line('Refreshing and exporting the message cache...');
+
+        $locales = Config::get('js-localization.locales');
+
+        if(!is_array($locales)) {
+          throw new ConfigException('Please set the "locales" config! See https://github.com/andywer/laravel-js-localization#configuration');
+        }
+
+        MessageCachingService::refreshCache();
+        $this->generateMessagesFile(Config::get('js-localization.storage_path'));
+
+        ConfigCachingService::refreshCache();
+        $this->generateConfigFile(Config::get('js-localization.storage_path'));
+    }
+
+    /**
+     * Generate the messages file.
+     *
+     * @param string $path
+     */
+    public function generateMessagesFile($path)
+    {
+        $messages = MessageCachingService::getMessagesJson();
+        $messages = $this->ensureBackwardsCompatibility($messages);
+
+        $contents  = 'Lang.addMessages(' . $messages . ');';
+
+        if (!is_dir($path)) {
+            mkdir($path, '0777', true);
+        }
+        $path = $path . 'messages';
+        File::put($path, $contents);
+
+        $this->line("Generated $path");
+    }
+
+    /**
+     * Generage the config file.
+     *
+     * @param string $path
+     */
+    public function generateConfigFile($path)
+    {
+        $config = ConfigCachingService::getConfigJson();
+        if ($config === '{}') {
+            return;
+        }
+
+        $contents = 'Config.addConfig(' . $config . ');';
+
+        if (!is_dir($path)) {
+            mkdir($path, '0777', true);
+        }
+        $path = $path . 'config';
+        File::put($path, $contents);
+
+        $this->line("Generated $path");
+    }
+
+    /**
+     * Transforms the cached data to stay compatible to old versions of the package.
+     *
+     * @param string $messages
+     * @return string
+     */
+    protected function ensureBackwardsCompatibility($messages)
+    {
+        if (preg_match('/^\\{"[a-z]{2}":/', $messages)) {
+            return $messages;
+        } else {
+            return '{"' . app()->getLocale() . '":' . $messages . '}';
+        }
+    }
+}

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Input\InputArgument;
 
 class RefreshCommand extends Command
 {
-
     /**
      * The console command name.
      *
@@ -43,76 +42,7 @@ class RefreshCommand extends Command
           throw new ConfigException('Please set the "locales" config! See https://github.com/andywer/laravel-js-localization#configuration');
         }
 
-        switch (Config::get('js-localization.storage')) {
-            case 'file':
-                $this->generateMessagesFile(Config::get('js-localization.storage_path'));
-                $this->generateConfigFile(Config::get('js-localization.storage_path'));
-                break;
-            // Cache is also the default option.
-            case 'cache':
-            default:
-                MessageCachingService::refreshCache();
-                ConfigCachingService::refreshCache();
-                break;
-        }
-    }
-
-    /**
-     * Generate the messages file.
-     *
-     * @param string $path
-     */
-    public function generateMessagesFile($path)
-    {
-        $messages = MessageCachingService::getMessagesJson();
-        $messages = $this->ensureBackwardsCompatibility($messages);
-
-        $contents  = 'Lang.addMessages(' . $messages . ');';
-
-        if (!is_dir($path)) {
-            mkdir($path, '0777', true);
-        }
-        $path = $path . 'messages';
-        File::put($path, $contents);
-
-        $this->line("Generated $path");
-    }
-
-    /**
-     * Generage the config file.
-     *
-     * @param string $path
-     */
-    public function generateConfigFile($path)
-    {
-        $config = ConfigCachingService::getConfigJson();
-        if ($config === '{}') {
-            return;
-        }
-
-        $contents = 'Config.addConfig(' . $config . ');';
-
-        if (!is_dir($path)) {
-            mkdir($path, '0777', true);
-        }
-        $path = $path . 'config';
-        File::put($path, $contents);
-
-        $this->line("Generated $path");
-    }
-
-    /**
-     * Transforms the cached data to stay compatible to old versions of the package.
-     *
-     * @param string $messages
-     * @return string
-     */
-    protected function ensureBackwardsCompatibility($messages)
-    {
-        if (preg_match('/^\\{"[a-z]{2}":/', $messages)) {
-            return $messages;
-        } else {
-            return '{"' . app()->getLocale() . '":' . $messages . '}';
-        }
+        MessageCachingService::refreshCache();
+        ConfigCachingService::refreshCache();
     }
 }

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -3,6 +3,7 @@ namespace JsLocalization\Console;
 
 use Config;
 use Illuminate\Console\Command;
+use File;
 use JsLocalization\Exceptions\ConfigException;
 use JsLocalization\Facades\ConfigCachingService;
 use JsLocalization\Facades\MessageCachingService;
@@ -42,8 +43,76 @@ class RefreshCommand extends Command
           throw new ConfigException('Please set the "locales" config! See https://github.com/andywer/laravel-js-localization#configuration');
         }
 
-        MessageCachingService::refreshCache();
-        ConfigCachingService::refreshCache();
+        switch (Config::get('js-localization.storage')) {
+            case 'file':
+                $this->generateMessagesFile(Config::get('js-localization.storage_path'));
+                $this->generateConfigFile(Config::get('js-localization.storage_path'));
+                break;
+            // Cache is also the default option.
+            case 'cache':
+            default:
+                MessageCachingService::refreshCache();
+                ConfigCachingService::refreshCache();
+                break;
+        }
     }
 
+    /**
+     * Generate the messages file.
+     *
+     * @param string $path
+     */
+    public function generateMessagesFile($path)
+    {
+        $messages = MessageCachingService::getMessagesJson();
+        $messages = $this->ensureBackwardsCompatibility($messages);
+
+        $contents  = 'Lang.addMessages(' . $messages . ');';
+
+        if (!is_dir($path)) {
+            mkdir($path, '0777', true);
+        }
+        $path = $path . 'messages';
+        File::put($path, $contents);
+
+        $this->line("Generated $path");
+    }
+
+    /**
+     * Generage the config file.
+     *
+     * @param string $path
+     */
+    public function generateConfigFile($path)
+    {
+        $config = ConfigCachingService::getConfigJson();
+        if ($config === '{}') {
+            return;
+        }
+
+        $contents = 'Config.addConfig(' . $config . ');';
+
+        if (!is_dir($path)) {
+            mkdir($path, '0777', true);
+        }
+        $path = $path . 'config';
+        File::put($path, $contents);
+
+        $this->line("Generated $path");
+    }
+
+    /**
+     * Transforms the cached data to stay compatible to old versions of the package.
+     *
+     * @param string $messages
+     * @return string
+     */
+    protected function ensureBackwardsCompatibility($messages)
+    {
+        if (preg_match('/^\\{"[a-z]{2}":/', $messages)) {
+            return $messages;
+        } else {
+            return '{"' . app()->getLocale() . '":' . $messages . '}';
+        }
+    }
 }

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -3,7 +3,6 @@ namespace JsLocalization\Console;
 
 use Config;
 use Illuminate\Console\Command;
-use File;
 use JsLocalization\Exceptions\ConfigException;
 use JsLocalization\Facades\ConfigCachingService;
 use JsLocalization\Facades\MessageCachingService;

--- a/src/JsLocalizationServiceProvider.php
+++ b/src/JsLocalizationServiceProvider.php
@@ -7,6 +7,7 @@ use Config;
 use View;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\File;
+use JsLocalization\Console\ExportCommand;
 use JsLocalization\Console\RefreshCommand;
 
 class JsLocalizationServiceProvider extends ServiceProvider {
@@ -40,6 +41,7 @@ class JsLocalizationServiceProvider extends ServiceProvider {
 		$this->loadViewsFrom(__DIR__.'/../resources/views', 'js-localization');
         
         $this->registerRefreshCommand();
+        $this->registerExportCommand();
 	}
 
 	/**
@@ -74,6 +76,19 @@ class JsLocalizationServiceProvider extends ServiceProvider {
 		});
 
 		$this->commands('js-localization.refresh');
+	}
+
+	/**
+	 * Register js-localization.export
+	 */
+	private function registerExportCommand()
+	{
+		$this->app->singleton('js-localization.export', function()
+		{
+			return new ExportCommand;
+		});
+
+		$this->commands('js-localization.export');
 	}
 
 }

--- a/src/JsLocalizationServiceProvider.php
+++ b/src/JsLocalizationServiceProvider.php
@@ -28,6 +28,10 @@ class JsLocalizationServiceProvider extends ServiceProvider {
         $this->publishes([
             __DIR__.'/../config/config.php' => config_path('js-localization.php')
         ]);
+
+        $this->publishes([
+            __DIR__.'/../public/js/localization.min.js' => public_path('vendor/js-localization'),
+        ], 'public');
         
         $this->mergeConfigFrom(
             __DIR__.'/../config/config.php', 'js-localization'

--- a/src/JsLocalizationServiceProvider.php
+++ b/src/JsLocalizationServiceProvider.php
@@ -30,7 +30,7 @@ class JsLocalizationServiceProvider extends ServiceProvider {
         ]);
 
         $this->publishes([
-            __DIR__.'/../public/js/localization.min.js' => public_path('vendor/js-localization'),
+            __DIR__.'/../public/js/localization.min.js' => public_path('vendor/js-localization/js-localization.min.js'),
         ], 'public');
         
         $this->mergeConfigFrom(


### PR DESCRIPTION
Possible fix for #29 

I'm not sure if the storage + storage_path approach is good, of if I should rather go for splitting the storage 'file' option into a 'public' and 'storage' option so the user can choose whether files should be written to 'public' so it can be included straight in the markup, or 'storage' for use in JS compilation.