### PR TITLE
Add suggestions to install clentfort/laravel-find-js-localizations to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
             "type": "vcs",
             "url": "git://github.com/orchestral/phpseclib.git"
         }
-    ]
+    ],
+    "suggest": {
+        "clentfort/laravel-find-js-localizations": "An Artisan command that helps finding untranslated strings in JavaScript-soruces"
+    }
 }


### PR DESCRIPTION
Suggest package "clentfort/laravel-find-js-localizations" which helps finding translation-keys in JavaScript files that are still missing from the projects lang-files.