### PR TITLE
Laravel 5.5 support for console commands

### DIFF
--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -32,7 +32,7 @@ class ExportCommand extends Command
      * @return void
      * @throws ConfigException
      */
-    public function fire()
+    public function handle()
     {
         $this->line('Refreshing and exporting the message cache...');
 

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -31,7 +31,7 @@ class RefreshCommand extends Command
      * @return void
      * @throws ConfigException
      */
-    public function fire()
+    public function handle()
     {
         $this->line('Refreshing the message cache...');
 


### PR DESCRIPTION
Here a little fix for Laravel 5.5. :-)

> *The fire Method*
> Any fire methods present on your Artisan commands should be renamed to handle.
https://laravel.com/docs/5.5/upgrade

@hmazter reported the issue.
https://github.com/andywer/laravel-js-localization/issues/40

Thanks ! :-)