### PR TITLE
Laravel 5.5 support for console commands (Backwards compatible with previous Laravel 5.x versions)

### DIFF
--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -32,7 +32,7 @@ class ExportCommand extends Command
      * @return void
      * @throws ConfigException
      */
-    public function fire()
+    public function handle()
     {
         $this->line('Refreshing and exporting the message cache...');
 
@@ -49,6 +49,18 @@ class ExportCommand extends Command
         ConfigCachingService::refreshCache();
         $configFilePath = $this->createPath('config.js');
         $this->generateConfigFile($configFilePath);
+    }
+    
+    /**
+     * Execute the console command.
+     * Compatibility with previous Laravel 5.x versions.
+     *
+     * @return void
+     * @throws ConfigException
+     */
+    public function fire()
+    {
+        $this->handle();
     }
 
     /**

--- a/src/Console/RefreshCommand.php
+++ b/src/Console/RefreshCommand.php
@@ -31,7 +31,7 @@ class RefreshCommand extends Command
      * @return void
      * @throws ConfigException
      */
-    public function fire()
+    public function handle()
     {
         $this->line('Refreshing the message cache...');
 
@@ -43,5 +43,17 @@ class RefreshCommand extends Command
 
         MessageCachingService::refreshCache();
         ConfigCachingService::refreshCache();
+    }
+    
+    /**
+     * Execute the console command.
+     * Compatibility with previous Laravel 5.x versions.
+     *
+     * @return void
+     * @throws ConfigException
+     */
+    public function fire()
+    {
+        $this->handle();
     }
 }


### PR DESCRIPTION
Renamed fire() to handle() and made fire() run handle()