### PR TITLE
Added a no cache option to the export command.

### DIFF
--- a/src/Caching/ConfigCachingService.php
+++ b/src/Caching/ConfigCachingService.php
@@ -8,10 +8,22 @@ use Event;
  * Class ConfigCachingService
  * @package JsLocalization\Caching
  */
-class ConfigCachingService extends AbstractCachingService {
+class ConfigCachingService extends AbstractCachingService
+{
 
+    /**
+     * The key used to cache the JSON encoded messages.
+     *
+     * @var string
+     */
     const CACHE_KEY = 'js-localization-config-json';
 
+    /**
+     * The key used to cache the timestamp of the last
+     * refreshCache() call.
+     *
+     * @var string
+     */
     const CACHE_TIMESTAMP_KEY = 'js-localization-config-last-modified';
 
 
@@ -21,6 +33,10 @@ class ConfigCachingService extends AbstractCachingService {
     }
 
     /**
+     * Refreshes the cache item containing the JSON encoded
+     * config object.
+     * Fires the 'JsLocalization.registerConfig' event.
+     *
      * @return void
      */
     public function refreshCache()
@@ -32,11 +48,12 @@ class ConfigCachingService extends AbstractCachingService {
     }
 
     /**
-     * @return string   The JSON-encoded config exports.
+     * @param bool $noCache
+     * @return mixed|string string   The JSON-encoded config exports.
      */
-    public function getConfigJson()
+    public function getConfigJson($noCache = false)
     {
-        if ($this->isDisabled()) {
+        if ($noCache or $this->isDisabled()) {
             return $this->createConfigJson();
         } else {
             return $this->getData();

--- a/src/Caching/MessageCachingService.php
+++ b/src/Caching/MessageCachingService.php
@@ -7,6 +7,10 @@ use Event;
 use Lang;
 use JsLocalization\Facades\JsLocalizationHelper;
 
+/**
+ * Class MessageCachingService
+ * @package JsLocalization\Caching
+ */
 class MessageCachingService extends AbstractCachingService
 {
 
@@ -32,20 +36,24 @@ class MessageCachingService extends AbstractCachingService
     }
 
     /**
-     * Returns the cached messages (already JSON encoded).
+     * Returns the messages (already JSON encoded), fresh if wanted.
      * Creates the necessary cache item if necessary.
      *
      * @return string JSON encoded messages object.
      */
-    public function getMessagesJson()
+    public function getMessagesJson($noCache = false)
     {
-        return $this->getData();
+        if ($noCache) {
+            return $this->createMessagesJson();
+        } else {
+            return $this->getData();
+        }
     }
 
     /**
-     * Refreshs the cache item containing the JSON encoded
+     * Refreshes the cache item containing the JSON encoded
      * messages object.
-     * Fires the 'JsLocalization.refresh' event.
+     * Fires the 'JsLocalization.registerMessages' event.
      *
      * @return void
      */
@@ -53,11 +61,20 @@ class MessageCachingService extends AbstractCachingService
     {
         Event::fire('JsLocalization.registerMessages');
 
+        $messagesJSON = $this->createMessagesJson();
+        $this->refreshCacheUsing($messagesJSON);
+    }
+
+    /**
+     * @return string
+     */
+    protected function createMessagesJson()
+    {
         $locales = $this->getLocales();
         $messageKeys = $this->getMessageKeys();
         $translatedMessages = $this->getTranslatedMessagesForLocales($messageKeys, $locales);
 
-        $this->refreshCacheUsing(json_encode($translatedMessages));
+        return json_encode($translatedMessages);
     }
 
     /**
@@ -157,5 +174,4 @@ class MessageCachingService extends AbstractCachingService
 
         return $messageKeys;
     }
-
 }

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -17,7 +17,14 @@ class ExportCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'js-localization:export {--no-cache : Ignores cached values and exports}';
+    protected $name = 'js-localization:export';
+
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'js-localization:export {--no-cache : Ignores cache completely}';
 
     /**
      * The console command description.
@@ -25,6 +32,18 @@ class ExportCommand extends Command
      * @var string
      */
     protected $description = "Refresh message cache and export to static files";
+
+    /**
+     *  Options defined for Laravel < 5.1
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['no-cache', 'd', InputOption::VALUE_NONE, 'Ignores cache completely'],
+        ];
+    }
 
     /**
      * Execute the console command.

--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -17,7 +17,7 @@ class ExportCommand extends Command
      *
      * @var string
      */
-    protected $name = 'js-localization:export';
+    protected $signature = 'js-localization:export {--no-cache : Ignores cached values and exports}';
 
     /**
      * The console command description.
@@ -34,7 +34,9 @@ class ExportCommand extends Command
      */
     public function handle()
     {
-        $this->line('Refreshing and exporting the message cache...');
+        $noCache = $this->option('no-cache');
+        if ($noCache == true) $this->line('Exporting messages and config...');
+        else $this->line('Refreshing and exporting the message and config cache...');
 
         $locales = Config::get('js-localization.locales');
 
@@ -42,13 +44,13 @@ class ExportCommand extends Command
           throw new ConfigException('Please set the "locales" config! See https://github.com/andywer/laravel-js-localization#configuration');
         }
 
-        MessageCachingService::refreshCache();
+        if ($noCache == false) MessageCachingService::refreshCache();
         $messagesFilePath = $this->createPath('messages.js');
-        $this->generateMessagesFile($messagesFilePath);
+        $this->generateMessagesFile($messagesFilePath, $noCache);
 
-        ConfigCachingService::refreshCache();
+        if ($noCache == false) ConfigCachingService::refreshCache();
         $configFilePath = $this->createPath('config.js');
-        $this->generateConfigFile($configFilePath);
+        $this->generateConfigFile($configFilePath, $noCache);
     }
     
     /**
@@ -85,11 +87,12 @@ class ExportCommand extends Command
      * Generate the messages file.
      *
      * @param string $path
+     * @param bool $noCache
      */
-    public function generateMessagesFile($path)
+    public function generateMessagesFile($path, $noCache = false)
     {
         $splitFiles = Config::get('js-localization.split_export_files');
-        $messages = MessageCachingService::getMessagesJson();
+        $messages = MessageCachingService::getMessagesJson($noCache);
 
         if ($splitFiles) {
             $this->generateMessageFiles(File::dirname($path), $messages);
@@ -129,10 +132,11 @@ class ExportCommand extends Command
      * Generate the config file.
      *
      * @param string $path
+     * @param bool $noCache
      */
-    public function generateConfigFile($path)
+    public function generateConfigFile($path, $noCache = false)
     {
-        $config = ConfigCachingService::getConfigJson();
+        $config = ConfigCachingService::getConfigJson($noCache);
         if ($config === '{}') {
             $this->line('No config specified. Config not written to file.');
             return;


### PR DESCRIPTION
The option "--no-cache" is good for us that use CI-server that does not have access to the cache, or people that want to simply export without using the cached values.