### PR TITLE
Set mode as integer when mkdir'ing

### DIFF
--- a/src/Console/ExportCommand.php
+++ b/src/Console/ExportCommand.php
@@ -96,7 +96,7 @@ class ExportCommand extends Command
     {
         $dir = Config::get('js-localization.storage_path');
         if (!is_dir($dir)) {
-            mkdir($dir, '0777', true);
+            mkdir($dir, 0777, true);
         }
 
         return $dir . $filename;


### PR DESCRIPTION
I've seen several times when I set up my project and do a `vendor:publish` of js-localization, that the access rights for the `public/vendor` folder is completely off and does not allow for my web user nor me to access it or add files to it. Doing some testing I found that there is a bit of a difference when setting the mode in php's `mkdir` function as a string compared to an int with a leading 0.

For instance:
```php
var_dump((int) '0777', 0777);
```
Will print out 
```
int(777)
int(511)
```

So when you in fact want the chmod mode of `777` you should either type it as `0777` or `'511'`?

Did a test by creating a test.php file and adding these two lines of code:

```php
mkdir('/var/www/test/foobar', '0777');
mkdir('/var/www/test/foobar2', 0777);
```

And then `ls -l`'ing afterwords:

![image](https://user-images.githubusercontent.com/65263/44838834-7cb4b400-ac3d-11e8-82c2-bcca55fff7fa.png)
