### PR TITLE
Removed global namespace facade usages

### DIFF
--- a/src/Caching/ConfigCachingService.php
+++ b/src/Caching/ConfigCachingService.php
@@ -1,8 +1,8 @@
 <?php
 namespace JsLocalization\Caching;
 
-use Config;
-use Event;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 
 /**
  * Class ConfigCachingService

--- a/src/Caching/MessageCachingService.php
+++ b/src/Caching/MessageCachingService.php
@@ -1,10 +1,10 @@
 <?php
 namespace JsLocalization\Caching;
 
-use Cache;
-use Config;
-use Event;
-use Lang;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Lang;
 use JsLocalization\Facades\JsLocalizationHelper;
 
 /**

--- a/src/Utils/Helper.php
+++ b/src/Utils/Helper.php
@@ -2,13 +2,13 @@
 namespace JsLocalization\Utils;
 
 use App;
-use Event;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use JsLocalization\Exceptions\FileNotFoundException;
 
 class Helper
 {
-    
+
     /**
      * Array of message keys. A set of messages that are
      * supposed to be exported to the JS code in addition


### PR DESCRIPTION
Facades are bad and pollute the global namespace. This results in a conflict when `pecl-event` is installed, see other issues:
* https://github.com/laravel/lumen-framework/issues/321
* `2.4.0-RC1` https://pecl.php.net/package-changelog.php?package=event