### PR TITLE
Added support for JSON translations

### DIFF
--- a/src/Caching/MessageCachingService.php
+++ b/src/Caching/MessageCachingService.php
@@ -122,7 +122,7 @@ class MessageCachingService extends AbstractCachingService
         $translatedMessages = [];
 
         foreach ($messageKeys as $key) {
-            $translation = Lang::get($key, [], $locale);
+            $translation = __($key, [], $locale);
 
             if (is_array($translation)) {
                 $flattened = $this->flattenTranslations($translation, $key.'.');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,9 +80,9 @@ class TestCase extends Orchestra\Testbench\TestCase
         $lang->shouldReceive('locale')->andReturn($locale);
 
         foreach ($this->testMessages[$locale] as $key=>$message) {
-            $lang->shouldReceive('get')
+            $lang->shouldReceive('getFromJson')
                 ->with($key)->andReturn($message);
-            $lang->shouldReceive('get')
+            $lang->shouldReceive('getFromJson')
                 ->with($key, m::any(), $locale)->andReturn($message);
         }
     }


### PR DESCRIPTION
With this pull request we will be able to use json messages that is supported in Laravel 5/6.

See https://laravel.com/docs/5.7/localization#using-translation-strings-as-keys